### PR TITLE
Quoll v0.0.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     chafer
     napari[all]
     opencv-python # cv2 functions for slice-alignment
+    quoll>=0.0.4
 
 
 [options.extras_require]
@@ -48,7 +49,7 @@ testing =
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/
 
 all =
-    quoll
+    # quoll
     imageio-ffmpeg #annoyingly napari 1.4.14 needs this but is not installed unless specified
 
 [options.packages.find]


### PR DESCRIPTION
Update to use Quoll v0.0.4

- Quoll now runs on the image data rather than image filenames
- Removes unnecessary dependencies from earlier versions of Quoll
- Adds progress bar (shows in the terminal)
- Allows users to choose calibration function (at the moment only no calibration or the RFI calibration function.)
